### PR TITLE
Final corrections (hopefully)

### DIFF
--- a/modules/database_modules/teacher_database.py
+++ b/modules/database_modules/teacher_database.py
@@ -2,6 +2,7 @@ import psycopg2
 import psycopg2.extras
 import json
 from contextlib import contextmanager
+from datetime import time
 
 
 # Function to load database credentials from a JSON file
@@ -68,6 +69,52 @@ class TeacherDatabase:
             except psycopg2.Error as e:
                 error_message = e.pgerror if e.pgerror else str(e)
                 print(f"Error retrieving classes: {error_message}")
+                return self.generate_response(success=False, error=error_message, status_code=500, error_code=e.pgcode)
+
+    def retrieve_teacher_exams(self, teacher_id):
+        if not teacher_id:
+            return self.generate_response(success=False, error='Teacher ID must be provided.', status_code=400)
+
+        with db_connection(self.credentials) as conn:
+            try:
+                cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+                # Check if the teacher exists
+                check_query = """
+                    SELECT 1 FROM users_teachers
+                    WHERE id = %s;
+                """
+                cur.execute(check_query, (teacher_id,))
+                existing_teacher = cur.fetchone()
+                if not existing_teacher:
+                    return self.generate_response(success=False, error='Teacher not found.', status_code=404)
+
+                # Retrieve all exams for classes taught by this teacher
+                query = """
+                    SELECT e.*, c.class_name
+                    FROM exams e
+                    JOIN classes c ON e.class_id = c.class_id
+                    WHERE c.teacher_id = %s;
+                """
+                cur.execute(query, (teacher_id,))
+                exams = cur.fetchall()
+                cur.close()
+
+                if not exams:
+                    return self.generate_response(success=False, error='No exams found for the teacher.', status_code=404)
+
+                exams_dict = [dict(row) for row in exams]
+
+                # Convert time objects to strings
+                for exam in exams_dict:
+                    for key, value in exam.items():
+                        if isinstance(value, time):
+                            exam[key] = value.strftime('%H:%M:%S')
+
+                return self.generate_response(success=True, error=None, status_code=200, data=exams_dict)
+
+            except psycopg2.Error as e:
+                error_message = e.pgerror if e.pgerror else str(e)
                 return self.generate_response(success=False, error=error_message, status_code=500, error_code=e.pgcode)
 
     # Private method to generate a consistent JSON response

--- a/routes/blueprints.py
+++ b/routes/blueprints.py
@@ -37,6 +37,7 @@ from routes.attendance_routes.get_class_attendance import get_class_attendance_b
 from routes.attendance_routes.get_student_attendance import get_student_attendance_bp
 from routes.attendance_routes.modify_attendance_route import modify_attendance_bp
 from routes.attendance_routes.delete_attendance_route import delete_attendance_bp
+from routes.teacher_routes.retrieve_teacher_exams_route import retrieve_teacher_exams_bp
 
 blueprints_list = [
     (verify_face_bp, '/api'),
@@ -77,5 +78,6 @@ blueprints_list = [
     (get_class_attendance_bp, '/api'),
     (get_student_attendance_bp, '/api'),
     (modify_attendance_bp, '/api'),
-    (delete_attendance_bp, '/api')
+    (delete_attendance_bp, '/api'),
+    (retrieve_teacher_exams_bp, '/api')
 ]

--- a/routes/teacher_routes/retrieve_teacher_exams_route.py
+++ b/routes/teacher_routes/retrieve_teacher_exams_route.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, request, jsonify
+from modules.database_modules.teacher_database import TeacherDatabase
+
+
+retrieve_teacher_exams_bp = Blueprint('retrieve_teacher_exams', __name__)
+db = TeacherDatabase()
+
+
+@retrieve_teacher_exams_bp.route('/teacher/exams', methods=['GET'])
+def retrieve_teacher_exams():
+    try:
+        teacher_id = request.args.get('teacher_id')
+        if not teacher_id:
+            return jsonify(TeacherDatabase.generate_response(
+                success=False,
+                error='Missing teacher_id parameter',
+                status_code=400
+            )), 400
+
+        result = db.retrieve_teacher_exams(teacher_id)
+        if not result['success']:
+            return jsonify(TeacherDatabase.generate_response(
+                success=False,
+                error=result['error'],
+                status_code=result['status_code']
+            )), result['status_code']
+
+        return jsonify(TeacherDatabase.generate_response(
+            success=True,
+            data=result['data'],
+            status_code=200
+        )), 200
+
+    except Exception as e:
+        return jsonify(TeacherDatabase.generate_response(
+            success=False,
+            error=str(e),
+            status_code=500
+        )), 500

--- a/static/swagger.yaml
+++ b/static/swagger.yaml
@@ -428,6 +428,15 @@ paths:
                     type: integer
 
   /api/login/teacher:
+    get:
+      description: New endpoint
+      responses:
+        200:
+          description: New response
+          content:
+            application/json:
+              schema:
+                :
     post:
       summary: Iniciar sesión de profesor
       description: Permite a un profesor iniciar sesión proporcionando su número de trabajo y contraseña.
@@ -783,6 +792,7 @@ paths:
           content:
             application/json:
               schema:
+                type: object
     delete:
       summary: Delete a student from a class
       description: Deletes a student from a class based on student_id and class_id.
@@ -3007,33 +3017,112 @@ paths:
                     }
                   ]
                   status_code: 200
+
+  /api/teacher/exams:
+      get:
+        summary: Retrieve exams for a teacher
+        description: Gets all exams for classes taught by a specific teacher.
+        tags:
+          - Profesores
+        parameters:
+          - in: query
+            name: teacher_id
+            required: true
+            schema:
+              type: string
+            description: ID of the teacher
+        responses:
+          '200':
+            description: Exams retrieved successfully
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    success:
+                      type: boolean
+                    data:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          exam_id:
+                            type: integer
+                          exam_name:
+                            type: string
+                          class_id:
+                            type: integer
+                          class_room:
+                            type: string
+                          date:
+                            type: string
+                            format: date-time
+                          hour:
+                            type: string
+                            format: time
+                    error:
+                      type: string
+                      nullable: true
+                    status_code:
+                      type: integer
+                example:
+                  success: true
+                  data: [
+                    {
+                      "exam_id": 6,
+                      "exam_name": "Medio Curso",
+                      "class_id": 7,
+                      "class_room": "1101",
+                      "date": "Thu, 16 Jan 2025 00:00:00 GMT",
+                      "hour": "13:40:00"
+                    },
+                    {
+                      "exam_id": 4,
+                      "exam_name": "Medio Curso",
+                      "class_id": 4,
+                      "class_room": "1101",
+                      "date": "Thu, 23 Jan 2025 00:00:00 GMT",
+                      "hour": "12:00:00"
+                    }
+                  ]
+                  error: null
+                  status_code: 200
           '400':
-            description: Missing class_id parameter
+            description: Missing teacher_id parameter
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/ErrorResponse'
-                example:
-                  success: false
-                  error: "Missing class_id parameter"
-                  status_code: 400
+                  type: object
+                  properties:
+                    success:
+                      type: boolean
+                    error:
+                      type: string
+                    status_code:
+                      type: integer
           '404':
-            description: Class not found
+            description: Teacher not found or no exams found
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/ErrorResponse'
-                example:
-                  success: false
-                  error: "Class not found."
-                  status_code: 404
+                  type: object
+                  properties:
+                    success:
+                      type: boolean
+                    error:
+                      type: string
+                    status_code:
+                      type: integer
           '500':
             description: Internal server error
             content:
               application/json:
                 schema:
-                  $ref: '#/components/schemas/ErrorResponse'
-                example:
-                  success: false
-                  error: "Database error"
-                  status_code: 500
+                  type: object
+                  properties:
+                    success:
+                      type: boolean
+                    error:
+                      type: string
+                    status_code:
+                      type: integer


### PR DESCRIPTION
This pull request introduces a new feature to retrieve all exams for classes taught by a specific teacher. It includes changes to the database module, routing, and API documentation to support this functionality.

### New Feature: Retrieve Teacher Exams

#### Database Module Updates:
* Added the `retrieve_teacher_exams` method in `TeacherDatabase` to fetch exams for a teacher's classes, including error handling for missing or invalid teacher IDs. The method converts `time` objects to string format before returning the data. (`modules/database_modules/teacher_database.py`, [modules/database_modules/teacher_database.pyR74-R119](diffhunk://#diff-3b574a4be8e43bb832ea03e59e2a62f6af793564f6366d197d8146b387221ed0R74-R119))
* Imported `time` from the `datetime` module to handle exam time conversion. (`modules/database_modules/teacher_database.py`, [modules/database_modules/teacher_database.pyR5](diffhunk://#diff-3b574a4be8e43bb832ea03e59e2a62f6af793564f6366d197d8146b387221ed0R5))

#### Routing Updates:
* Created a new route `retrieve_teacher_exams_route.py` to handle the `/teacher/exams` endpoint, which calls the database method and returns JSON responses for success and error cases. (`routes/teacher_routes/retrieve_teacher_exams_route.py`, [routes/teacher_routes/retrieve_teacher_exams_route.pyR1-R39](diffhunk://#diff-ddb50121ffd516daf70b86d944f659fe98b4263fef129e26caff5147ab438d65R1-R39))
* Registered the new route in the `blueprints.py` file to make it accessible via the API. (`routes/blueprints.py`, [[1]](diffhunk://#diff-a60c9e516e1d1531660af7490653e0193146228408b52f27ef7779819b1795fbR40) [[2]](diffhunk://#diff-a60c9e516e1d1531660af7490653e0193146228408b52f27ef7779819b1795fbL80-R82)

#### API Documentation Updates:
* Added the `/api/teacher/exams` endpoint to `swagger.yaml`, documenting its purpose, parameters, and possible responses, including success and error scenarios. (`static/swagger.yaml`, [static/swagger.yamlL3010-R3128](diffhunk://#diff-9c8ca415b79ffb56232c595f1440a3e1cc07bbe3f4aca1e67eae1802be336642L3010-R3128))